### PR TITLE
Set term_kill if no args so that :qall does not fail

### DIFF
--- a/autoload/pterm.vim
+++ b/autoload/pterm.vim
@@ -20,6 +20,7 @@ function! pterm#open(q_bang, q_args, count) abort
       let bnr = term_start(args, #{
         \   hidden: 1,
         \   term_finish: 'close',
+        \   term_kill: empty(a:q_args) ? 'term' : '',
         \ })
     endif
   endif


### PR DESCRIPTION
term_killを指定するとバッファを閉じるときに自動でkillしてくれるそうなので、引数のない `:PTermOpen` で開いたターミナルにはそれを設定するようにしました。