### PR TITLE
Fix the title of popup is not set when `g:pterm_options = #{line: 1}`

### DIFF
--- a/autoload/pterm.vim
+++ b/autoload/pterm.vim
@@ -153,7 +153,7 @@ endfunction
 function! s:show_tabs() abort
     let winid = s:get_winid_of_pterm()
     let pos = popup_getpos(winid)
-    if 1 <= pos['line'] - 1
+    if 1 <= pos['line']
         let offset = 0
         let xs = []
         for n in pterm#list()


### PR DESCRIPTION
`g:pterm_options = #{line: 1}` のとき、ptermのタイトルが設定されないようです。
この `-1` が不要と思われるので削除しました。